### PR TITLE
Add offline screen when no connection is available

### DIFF
--- a/resources/layouts/offline.xml
+++ b/resources/layouts/offline.xml
@@ -1,0 +1,5 @@
+<layout id="OfflineLayout">
+    <label x="center" y="80" font="Graphics.FONT_LARGE" text="@Strings.prompt" color="Gfx.COLOR_RED" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+    <label x="center" y="120" font="Graphics.FONT_SMALL" text="@Strings.label_offline1" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+    <label x="center" y="150" font="Graphics.FONT_SMALL" text="@Strings.label_offline2" color="Gfx.COLOR_WHITE" justification="Gfx.TEXT_JUSTIFY_CENTER" />
+</layout>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -4,6 +4,8 @@
     <string id="prompt">Tesla</string>
     <string id="press_start1">Press start to</string>
     <string id="press_start2">wake vehicle...</string>
+    <string id="label_offline1">Phone connection</string>
+    <string id="label_offline2">is required</string>
 
     <string id="menu_label_1">Reset...</string>
     <string id="menu_label_honk">Honk</string>

--- a/source/OfflineView.mc
+++ b/source/OfflineView.mc
@@ -1,0 +1,10 @@
+using Toybox.WatchUi as Ui;
+
+class OfflineView extends Ui.View {
+
+    //! Load your resources here
+    function onLayout(dc) {
+        setLayout(Rez.Layouts.OfflineLayout(dc));
+    }
+
+}

--- a/source/OfflineView.mc
+++ b/source/OfflineView.mc
@@ -2,6 +2,10 @@ using Toybox.WatchUi as Ui;
 
 class OfflineView extends Ui.View {
 
+    function initialize() {
+        View.initialize();
+    }
+
     //! Load your resources here
     function onLayout(dc) {
         setLayout(Rez.Layouts.OfflineLayout(dc));

--- a/source/SimpleApp.mc
+++ b/source/SimpleApp.mc
@@ -1,5 +1,6 @@
 using Toybox.Application as App;
 using Toybox.WatchUi as Ui;
+using Toybox.System as Sys;
 
 class QuickTesla extends App.AppBase {
 
@@ -17,6 +18,9 @@ class QuickTesla extends App.AppBase {
 
     //! Return the initial view of your application here
     function getInitialView() {
+        if (!Sys.getDeviceSettings().connectionAvailable) {
+            return [ new OfflineView() ];
+        }
         return [ new SimpleView(), new SimpleDelegate() ];
     }
 


### PR DESCRIPTION
When no connection is available, there is no need to try to ping the vehicle.

An offline screen will display a help text "Phone connection is required", and no action will be possible on the widget.

![image](https://user-images.githubusercontent.com/312886/70456982-85866d80-1aaf-11ea-8a22-b8f66db2ba5d.png)
