### PR TITLE
fix: get the vehicle name from the vehicle_state

### DIFF
--- a/source/MainView.mc
+++ b/source/MainView.mc
@@ -110,7 +110,7 @@ class MainView extends Ui.View {
             if (_data._vehicle_data != null) {
                 // Retrieve and display the vehicle name
                 var name_drawable = View.findDrawableById("name");
-                var vehicle_name = _data._vehicle_data.get("display_name");
+                var vehicle_name = _data._vehicle_data.get("vehicle_state").get("vehicle_name");
                 Application.getApp().setProperty("vehicle_name", vehicle_name);
                 name_drawable.setText(vehicle_name);
                 name_drawable.draw(dc);


### PR DESCRIPTION
Tesla removed the `display_name` property from the `vehicle_data` response. It is now found under under `vehicle_state` subsection of the `vehicle_data` response.

This PR addresses this issue.

### Tests
- [x] Code tested on Connect IQ Device simulator with fenix 6® pro
- [x] App tested on real fenix 6® pro

Fixes #42 

### Before the fix

![image](https://github.com/srwalter/garmin-tesla/assets/683020/b9d6aeea-87cf-40a3-b123-e5a40e1e6061)

```
Error: Unhandled Exception
Exception: UnexpectedTypeException: Expected Number/Float/Boolean/Long/Double, given null
Stack: 
  - setText() at 704b03c0.mb:5530 0x300043fd 
  - onUpdate() at /Users/bdoncieu/projects/garmin-tesla/source/MainView.mc:115 0x1000122f 

Encountered app crash.
```

### After the fix

![image](https://github.com/srwalter/garmin-tesla/assets/683020/2fc70b85-2e07-4dc5-b3be-556e825253df)


